### PR TITLE
fix(ci): fetch remote tag before moving major version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ steps.initial_tag.outputs.new_tag || steps.bump_tag.outputs.new_tag }}
         run: |
+          git fetch origin tag "${RELEASE_TAG}" --no-tags
           major="${RELEASE_TAG%%.*}"
           git tag -f "${major}" "${RELEASE_TAG}"
           git push -f origin "${major}"


### PR DESCRIPTION
## Summary

- Fix release workflow failure where `git tag -f` couldn't resolve the newly created tag
- The `mathieudutour/github-tag-action` creates tags via the GitHub API (remotely), so the local checkout needs to fetch the tag before referencing it

## Test plan

- [ ] Merge to main and verify the release workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)