### PR TITLE
ci(release): remove v2.0.0 bootstrap logic from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,26 +11,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Check for existing v2 tags
-        id: check
-        run: |
-          if git tag -l 'v2.*' | grep -q .; then
-            echo "has_v2=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_v2=false" >> "$GITHUB_OUTPUT"
-          fi
-      # Bootstrap v2.0.0 if no v2.x tags exist yet
-      - name: Create initial v2 tag
-        if: steps.check.outputs.has_v2 == 'false'
-        id: initial_tag
-        uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          custom_tag: "2.0.0"
-          tag_prefix: v
-      # Bump patch from latest v2.x tag
       - name: Bump version and create tag
-        if: steps.check.outputs.has_v2 == 'true'
         id: bump_tag
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
@@ -41,11 +22,11 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
-          tag_name: ${{ steps.initial_tag.outputs.new_tag || steps.bump_tag.outputs.new_tag }}
+          tag_name: ${{ steps.bump_tag.outputs.new_tag }}
           generate_release_notes: true
       - name: Move major version tag
         env:
-          RELEASE_TAG: ${{ steps.initial_tag.outputs.new_tag || steps.bump_tag.outputs.new_tag }}
+          RELEASE_TAG: ${{ steps.bump_tag.outputs.new_tag }}
         run: |
           git fetch origin tag "${RELEASE_TAG}" --no-tags
           major="${RELEASE_TAG%%.*}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A GitHub Action (`cgrindel/gha_set_up_bazel@v2`) that wraps `bazel-contrib/setup-bazel` with two
+fixes: removing the `startup --output_base` override (prevents lock contention in integration tests)
+and enabling `--config=ci` in `~/.bazelrc`.
+
+The action is defined entirely in `action.yml` (composite action) — there is no build step or
+compiled code.
+
+## Testing
+
+Tests run in CI only (GitHub Actions). The CI workflow (`.github/workflows/ci.yml`) exercises the
+action with `uses: ./` and verifies behavior by inspecting `~/.bazelrc`. There are no local test
+commands.
+
+The `ci/` directory contains a minimal Bazel workspace used by CI to validate that Bazel works after
+the action runs:
+
+```bash
+cd ci && bazel test //...
+```
+
+## Release
+
+Merges to `main` trigger `.github/workflows/release.yml`, which auto-bumps the patch version tag
+and moves the `v2` major version tag forward.
+
+## Key Files
+
+- `action.yml` — the entire action implementation
+- `.github/workflows/ci.yml` — CI tests (two scenarios: default settings, CI config disabled)
+- `.github/workflows/release.yml` — automated release on merge to main
+- `ci/` — test Bazel workspace with `ci.bazelrc` and `shared.bazelrc`


### PR DESCRIPTION
## Summary

- Remove the dead v2.0.0 bootstrap steps (`Check for existing v2 tags` and `Create initial v2 tag`) from the release workflow now that v2.0.0 has been released
- Simplify tag references to use `steps.bump_tag` directly instead of fallback expressions
- Add CLAUDE.md with project guidance for Claude Code

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/claude-code)