### PR TITLE
fix: prepend newline when appending ci config to bazelrc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,12 @@ jobs:
         run: |
           cd ci
           bazel test //...
-      - name: Verify ci config enabled
+      - name: Verify ci config is on its own line
         shell: bash
         run: |
-          grep -q 'common --config=ci' ~/.bazelrc || \
-            (echo >&2 "Expected --config=ci in ~/.bazelrc" && exit 1)
+          grep -qx 'common --config=ci' ~/.bazelrc || \
+            (echo >&2 "Expected 'common --config=ci' on its own line in ~/.bazelrc"; \
+             echo >&2 "Actual contents:"; cat >&2 ~/.bazelrc; exit 1)
       - name: Verify output_base override removed
         shell: bash
         run: |

--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,11 @@ runs:
         else
           echo "::notice::startup --output_base not found in ~/.bazelrc -- setup-bazel may have changed behavior"
         fi
+    # setup-bazel joins bazelrc entries with "\n" but omits a trailing
+    # newline, so a plain >> append concatenates onto the last line.
+    # Use printf to prepend a newline before appending.
     - name: Enable ci config
       if: ${{ inputs.enable_ci_config == 'true' }}
       shell: bash
       run: |
-        echo "common --config=ci" >> ~/.bazelrc
+        printf '\ncommon --config=ci\n' >> ~/.bazelrc


### PR DESCRIPTION
## Summary

- **Fix:** `setup-bazel` omits a trailing newline in `~/.bazelrc`, so `echo >> ~/.bazelrc` concatenated `common --config=ci` onto the last line instead of adding it as a new line. Switched to `printf '\ncommon --config=ci\n'` to ensure it lands on its own line.
- **Test:** Strengthened CI verification from `grep -q` to `grep -qx` so the test catches this class of bug (directive appended without a newline separator). Added diagnostic output on failure.

## Test plan

- [ ] CI `default_settings` job passes — `grep -qx 'common --config=ci'` confirms the directive is on its own line
- [ ] CI `ci_config_disabled` job still passes
- [ ] `bazel test //...` succeeds in the `ci/` workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)